### PR TITLE
Name order

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -39,7 +39,11 @@ class App extends Component {
             },
 
             dataContext: {
-                userName: 'unknown',
+                userName: {
+                    firstName: '',
+                    lastName: '',
+                    fullName: ''
+                },
                 avatarSrc: '/images/noAvatar.svg',
                 setUsername: this.setUsername,
                 setAvatarSrc: this.setAvatarSrc
@@ -48,19 +52,19 @@ class App extends Component {
     }
 
     toggleHamburger = () => {
-        const uiContext = { ...this.state.uiContext };
+        const { uiContext } = this.state;
         uiContext.isHamburgerOpen = !this.state.uiContext.isHamburgerOpen;
         this.setState({ uiContext });
     };
 
     closeHamburger = () => {
-        const uiContext = { ...this.state.uiContext };
+        const { uiContext } = this.state;
         uiContext.isHamburgerOpen = false;
         this.state.uiContext.isHamburgerOpen && this.setState({ uiContext });
     };
 
     setAccess = (isSuperuser, isFinanceAdmin, isEventAdmin, isYogaAdmin) => {
-        const uiContext = { ...this.state.uiContext };
+        const { uiContext } = this.state;
         uiContext.isSuperuser = isSuperuser;
         uiContext.isFinanceAdmin = isFinanceAdmin;
         uiContext.isEventAdmin = isEventAdmin;
@@ -69,20 +73,34 @@ class App extends Component {
     };
 
     changeLang = (lang) => {
-        const uiContext = { ...this.state.uiContext };
+        const { uiContext } = this.state;
+        const { dataContext } = this.state;
+        const { userName } = dataContext;
+        const { firstName, lastName } = userName;
+
         uiContext.lang = lang;
         uiContext.dictionary = dictionaryList[lang];
-        this.setState({ uiContext });
+
+        userName.fullName = lang === 'hu' ? `${lastName} ${firstName}` : `${firstName} ${lastName}`;
+        dataContext.userName = userName;
+
+        this.setState({ uiContext, dataContext });
     };
 
     setUsername = (firstName, lastName) => {
-        const dataContext = { ...this.state.dataContext };
-        dataContext.userName = `${firstName} ${lastName}`;
+        const { dataContext } = this.state;
+        const lang = localStorage.getItem('lang');
+        dataContext.userName = {
+            firstName: firstName,
+            lastName: lastName,
+            // Full name order depends on language
+            fullName: lang === 'hu' ? `${lastName} ${firstName}` : `${firstName} ${lastName}`
+        }
         this.setState({ dataContext });
     }
 
     setAvatarSrc = (src) => {
-        const dataContext = { ...this.state.dataContext };
+        const { dataContext } = this.state;
         dataContext.avatarSrc = src;
         this.setState({ dataContext });
     }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -21,6 +21,9 @@ class App extends Component {
             localStorage.setItem('lang', 'hu');
         }
 
+        this.englishNameOrder = 1;
+        this.hungarianNameOrder = -1;
+
         this.state = {
             uiContext: {
                 isHamburgerOpen: false,
@@ -43,7 +46,7 @@ class App extends Component {
                     firstName: '',
                     lastName: '',
                     fullName: '',
-                    nameOrder: localStorage.getItem('lang') === 'hu' ? -1 : 1
+                    nameOrder: localStorage.getItem('lang') === 'hu' ? this.hungarianNameOrder : this.englishNameOrder
                 },
                 avatarSrc: '/images/noAvatar.svg',
                 setUsername: this.setUsername,
@@ -57,7 +60,7 @@ class App extends Component {
         return lang === 'hu' ? `${lastName} ${firstName}` : `${firstName} ${lastName}`;
     }
 
-    getNameOrder = () => this.state.uiContext.lang === 'hu' ? -1 : 1;
+    getNameOrder = () => this.state.uiContext.lang === 'hu' ? this.hungarianNameOrder : this.englishNameOrder;
 
     toggleHamburger = () => {
         const { uiContext } = this.state;
@@ -83,8 +86,7 @@ class App extends Component {
     changeLang = (lang) => {
         const { uiContext } = this.state;
         const { dataContext } = this.state;
-        const { userName } = dataContext;
-        const { firstName, lastName } = userName;
+        const { firstName, lastName } = dataContext.userName;
 
         uiContext.lang = lang;
         uiContext.dictionary = dictionaryList[lang];

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -61,7 +61,7 @@ class App extends Component {
 
     toggleHamburger = () => {
         const { uiContext } = this.state;
-        uiContext.isHamburgerOpen = !this.state.uiContext.isHamburgerOpen;
+        uiContext.isHamburgerOpen = !uiContext.isHamburgerOpen;
         this.setState({ uiContext });
     };
 
@@ -90,7 +90,8 @@ class App extends Component {
         uiContext.dictionary = dictionaryList[lang];
 
         dataContext.userName = {
-            ...userName,
+            firstName,
+            lastName,
             fullName: this.getFullName(firstName, lastName),
             nameOrder: this.getNameOrder()
         };
@@ -101,8 +102,8 @@ class App extends Component {
     setUsername = (firstName, lastName) => {
         const { dataContext } = this.state;
         dataContext.userName = {
-            firstName: firstName,
-            lastName: lastName,
+            firstName,
+            lastName,
             // Full name order depends on language
             fullName: this.getFullName(firstName, lastName),
             nameOrder: this.getNameOrder()

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -21,8 +21,8 @@ class App extends Component {
             localStorage.setItem('lang', 'hu');
         }
 
-        this.englishNameOrder = 1;
-        this.hungarianNameOrder = -1;
+        this.englishNameOrder = 'normal';
+        this.hungarianNameOrder = 'reverse';
 
         this.state = {
             uiContext: {
@@ -103,13 +103,15 @@ class App extends Component {
 
     setUsername = (firstName, lastName) => {
         const { dataContext } = this.state;
+
         dataContext.userName = {
             firstName,
             lastName,
             // Full name order depends on language
             fullName: this.getFullName(firstName, lastName),
             nameOrder: this.getNameOrder()
-        }
+        };
+
         this.setState({ dataContext });
     }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -57,6 +57,8 @@ class App extends Component {
         return lang === 'hu' ? `${lastName} ${firstName}` : `${firstName} ${lastName}`;
     }
 
+    getNameOrder = () => this.state.uiContext.lang === 'hu' ? -1 : 1;
+
     toggleHamburger = () => {
         const { uiContext } = this.state;
         uiContext.isHamburgerOpen = !this.state.uiContext.isHamburgerOpen;
@@ -87,8 +89,11 @@ class App extends Component {
         uiContext.lang = lang;
         uiContext.dictionary = dictionaryList[lang];
 
-        userName.fullName = this.getFullName(firstName, lastName);
-        dataContext.userName = userName;
+        dataContext.userName = {
+            ...userName,
+            fullName: this.getFullName(firstName, lastName),
+            nameOrder: this.getNameOrder()
+        };
 
         this.setState({ uiContext, dataContext });
     };
@@ -99,7 +104,8 @@ class App extends Component {
             firstName: firstName,
             lastName: lastName,
             // Full name order depends on language
-            fullName: this.getFullName(firstName, lastName)
+            fullName: this.getFullName(firstName, lastName),
+            nameOrder: this.getNameOrder()
         }
         this.setState({ dataContext });
     }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -57,8 +57,6 @@ class App extends Component {
         return lang === 'hu' ? `${lastName} ${firstName}` : `${firstName} ${lastName}`;
     }
 
-    getNameOrder = () => this.state.uiContext.lang === 'hu' ? this.hungarianNameOrder : this.englishNameOrder;
-
     toggleHamburger = () => {
         const { uiContext } = this.state;
         uiContext.isHamburgerOpen = !uiContext.isHamburgerOpen;

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -21,9 +21,6 @@ class App extends Component {
             localStorage.setItem('lang', 'hu');
         }
 
-        this.englishNameOrder = 'normal';
-        this.hungarianNameOrder = 'reverse';
-
         this.state = {
             uiContext: {
                 isHamburgerOpen: false,
@@ -45,9 +42,9 @@ class App extends Component {
                 userName: {
                     firstName: '',
                     lastName: '',
-                    fullName: '',
-                    nameOrder: localStorage.getItem('lang') === 'hu' ? this.hungarianNameOrder : this.englishNameOrder
+                    fullName: ''
                 },
+                getFullName: this.getFullName,
                 avatarSrc: '/images/noAvatar.svg',
                 setUsername: this.setUsername,
                 setAvatarSrc: this.setAvatarSrc
@@ -94,8 +91,7 @@ class App extends Component {
         dataContext.userName = {
             firstName,
             lastName,
-            fullName: this.getFullName(firstName, lastName),
-            nameOrder: this.getNameOrder()
+            fullName: this.getFullName(firstName, lastName)
         };
 
         this.setState({ uiContext, dataContext });
@@ -107,9 +103,7 @@ class App extends Component {
         dataContext.userName = {
             firstName,
             lastName,
-            // Full name order depends on language
-            fullName: this.getFullName(firstName, lastName),
-            nameOrder: this.getNameOrder()
+            fullName: this.getFullName(firstName, lastName)
         };
 
         this.setState({ dataContext });

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -33,7 +33,7 @@ class App extends Component {
                 isYogaAdmin: false,
                 setAccess: this.setAccess,
 
-                lang: 'hu',
+                lang: localStorage.getItem('lang'),
                 dictionary: dictionaryList[localStorage.getItem('lang')],
                 changeLang: this.changeLang
             },
@@ -42,13 +42,19 @@ class App extends Component {
                 userName: {
                     firstName: '',
                     lastName: '',
-                    fullName: ''
+                    fullName: '',
+                    nameOrder: localStorage.getItem('lang') === 'hu' ? -1 : 1
                 },
                 avatarSrc: '/images/noAvatar.svg',
                 setUsername: this.setUsername,
                 setAvatarSrc: this.setAvatarSrc
             }
         };
+    }
+
+    getFullName = (firstName, lastName) => {
+        const { lang } = this.state.uiContext;
+        return lang === 'hu' ? `${lastName} ${firstName}` : `${firstName} ${lastName}`;
     }
 
     toggleHamburger = () => {
@@ -81,7 +87,7 @@ class App extends Component {
         uiContext.lang = lang;
         uiContext.dictionary = dictionaryList[lang];
 
-        userName.fullName = lang === 'hu' ? `${lastName} ${firstName}` : `${firstName} ${lastName}`;
+        userName.fullName = this.getFullName(firstName, lastName);
         dataContext.userName = userName;
 
         this.setState({ uiContext, dataContext });
@@ -89,12 +95,11 @@ class App extends Component {
 
     setUsername = (firstName, lastName) => {
         const { dataContext } = this.state;
-        const lang = localStorage.getItem('lang');
         dataContext.userName = {
             firstName: firstName,
             lastName: lastName,
             // Full name order depends on language
-            fullName: lang === 'hu' ? `${lastName} ${firstName}` : `${firstName} ${lastName}`
+            fullName: this.getFullName(firstName, lastName)
         }
         this.setState({ dataContext });
     }

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -181,7 +181,7 @@ const Header = (props) => {
                             className="d-none d-sm-flex"
                         />
                         <Figure.Caption className={`avatar-name d-none ${searching ? '' : 'd-sm-flex'}`} as='h2'>
-                            {userName}
+                            {userName.fullName}
                         </Figure.Caption>
                     </Figure>
                     <h1 className={`page-name m-0 ${searching ? 'd-none' : ''}`}>{props.activePage}</h1>

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -7,6 +7,7 @@ import Alert from '../../components/Alert/Alert';
 import Navbar from '../Navbar/Navbar';
 import SearchBar from '../Search/SearchBar';
 import MemberDetails from '../MemberDetails/MemberDetails';
+import ActiveUserNameWrapper from '../NameWrappers/ActiveUserName/ActiveUserNameWrapper';
 
 import { ReactComponent as SearchIcon } from '../icons/search.svg';
 import { ReactComponent as CrossIcon } from '../icons/cross.svg';
@@ -181,7 +182,7 @@ const Header = (props) => {
                             className="d-none d-sm-flex"
                         />
                         <Figure.Caption className={`avatar-name d-none ${searching ? '' : 'd-sm-flex'}`} as='h2'>
-                            {userName.fullName}
+                            <ActiveUserNameWrapper />
                         </Figure.Caption>
                     </Figure>
                     <h1 className={`page-name m-0 ${searching ? 'd-none' : ''}`}>{props.activePage}</h1>

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -8,6 +8,7 @@ import Navbar from '../Navbar/Navbar';
 import SearchBar from '../Search/SearchBar';
 import MemberDetails from '../MemberDetails/MemberDetails';
 import ActiveUserNameWrapper from '../NameWrappers/ActiveUserName/ActiveUserNameWrapper';
+import AnyUserNameWrapper from '../NameWrappers/AnyUserName/AnyUserNameWrapper';
 
 import { ReactComponent as SearchIcon } from '../icons/search.svg';
 import { ReactComponent as CrossIcon } from '../icons/cross.svg';
@@ -219,7 +220,12 @@ const Header = (props) => {
                                             <li key={key} onClick={() => { handleSearchResultClick(user._id); }}>
                                                 <p>
                                                     { user.spiritualName !== '-' && <span>{user.spiritualName}</span> }
-                                                    <span>{user.firstName} {user.lastName}</span>
+                                                    <span>
+                                                        <AnyUserNameWrapper
+                                                            firstName={user.firstName}
+                                                            lastName={user.lastName}
+                                                        />
+                                                    </span>
                                                 </p>
                                             </li>
                                         );

--- a/client/src/components/MemberCard/MemberCard.js
+++ b/client/src/components/MemberCard/MemberCard.js
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { UIcontext } from '../contexts/UIcontext/UIcontext';
 import AnyUserNameWrapper from '../NameWrappers/AnyUserName/AnyUserNameWrapper'
+import { UIcontext } from '../contexts/UIcontext/UIcontext';
 import './MemberCard.scss';
 
 const MemberCard = (props) => {

--- a/client/src/components/MemberCard/MemberCard.js
+++ b/client/src/components/MemberCard/MemberCard.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { UIcontext } from '../contexts/UIcontext/UIcontext';
+import AnyUserNameWrapper from '../NameWrappers/AnyUserName/AnyUserNameWrapper'
 import './MemberCard.scss';
 
 const MemberCard = (props) => {
@@ -15,7 +16,12 @@ const MemberCard = (props) => {
                 <img src={profileImg} alt="Avatar" />
             </div>
             <div className="member-content">
-                <p className="card-name">{`${firstName} ${lastName}`}</p>
+                <p className="card-name">
+                    <AnyUserNameWrapper
+                        firstName={firstName}
+                        lastName={lastName}
+                    />
+                </p>
                 <hr className="card-line"></hr>
                 <p className="card-spiritual-name">{spiritualName}</p>
             </div>

--- a/client/src/components/MemberDetails/MemberDetails.js
+++ b/client/src/components/MemberDetails/MemberDetails.js
@@ -1,6 +1,7 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import GenericDialog from '../Form/GenericDialog/GenericDialog';
+import AnyUserNameWrapper from '../NameWrappers/AnyUserName/AnyUserNameWrapper'
 import { UIcontext } from '../contexts/UIcontext/UIcontext';
 import { ReactComponent as CopyIcon } from './copy.svg';
 import './MemberDetails.scss';
@@ -40,7 +41,12 @@ const MemberDetails = (props) => {
 
     return (
         <GenericDialog
-            title={`${data.firstName} ${data.lastName}`}
+            title={
+                <AnyUserNameWrapper
+                    firstName={data.firstName}
+                    lastName={data.lastName}
+                />
+            }
             reject={REJECT}
             handleClose={closeDialog}
         >

--- a/client/src/components/NameWrappers/ActiveUserName/ActiveUserNameWrapper.js
+++ b/client/src/components/NameWrappers/ActiveUserName/ActiveUserNameWrapper.js
@@ -4,6 +4,6 @@ import { DataContext } from '../../contexts/DataContext/DataContext';
 const ActiveUserNameWrapper = (props) => {
     const { fullName } = useContext(DataContext).userName;
     return <>{fullName}</>;
-}
+};
 
 export default ActiveUserNameWrapper;

--- a/client/src/components/NameWrappers/ActiveUserName/ActiveUserNameWrapper.js
+++ b/client/src/components/NameWrappers/ActiveUserName/ActiveUserNameWrapper.js
@@ -1,0 +1,9 @@
+import React, { useContext } from 'react';
+import { DataContext } from '../../contexts/DataContext/DataContext';
+
+const ActiveUserNameWrapper = (props) => {
+    const { fullName } = useContext(DataContext).userName;
+    return <>{fullName}</>;
+}
+
+export default ActiveUserNameWrapper;

--- a/client/src/components/NameWrappers/AnyUserName/AnyUserNameWrapper.js
+++ b/client/src/components/NameWrappers/AnyUserName/AnyUserNameWrapper.js
@@ -3,13 +3,10 @@ import PropTypes from 'prop-types';
 import { DataContext } from '../../contexts/DataContext/DataContext';
 
 const AnyUserNameWrapper = (props) => {
-    const { nameOrder } = useContext(DataContext).userName;
+    const { getFullName } = useContext(DataContext);
     const { firstName, lastName } = props;
-    const names = [firstName, lastName];
 
-    const namesInOrder = nameOrder === 'reverse' ? names.reverse() : names;
-
-    return <>{namesInOrder.join(' ')}</>;
+    return <>{getFullName(firstName, lastName)}</>;
 };
 
 AnyUserNameWrapper.propTypes = {

--- a/client/src/components/NameWrappers/AnyUserName/AnyUserNameWrapper.js
+++ b/client/src/components/NameWrappers/AnyUserName/AnyUserNameWrapper.js
@@ -1,0 +1,19 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { DataContext } from '../../contexts/DataContext/DataContext';
+
+const AnyUserNameWrapper = (props) => {
+    const { nameOrder } = useContext(DataContext).userName;
+    const { firstName, lastName } = props;
+
+    // ['John', 'Doe'].sort(() => -1)   ===   ['Doe', 'John']
+    return <>{[firstName, lastName].sort(() => nameOrder).join(' ')}</>;
+}
+
+AnyUserNameWrapper.propTypes = {
+    firstName: PropTypes.string.isRequired,
+    lastName: PropTypes.string.isRequired
+}
+
+export default AnyUserNameWrapper;
+

--- a/client/src/components/NameWrappers/AnyUserName/AnyUserNameWrapper.js
+++ b/client/src/components/NameWrappers/AnyUserName/AnyUserNameWrapper.js
@@ -5,15 +5,16 @@ import { DataContext } from '../../contexts/DataContext/DataContext';
 const AnyUserNameWrapper = (props) => {
     const { nameOrder } = useContext(DataContext).userName;
     const { firstName, lastName } = props;
+    const names = [firstName, lastName];
 
-    // ['John', 'Doe'].sort(() => -1)   ===   ['Doe', 'John']
-    return <>{[firstName, lastName].sort(() => nameOrder).join(' ')}</>;
-}
+    const namesInOrder = nameOrder === 'reverse' ? names.reverse() : names;
+
+    return <>{namesInOrder.join(' ')}</>;
+};
 
 AnyUserNameWrapper.propTypes = {
     firstName: PropTypes.string.isRequired,
     lastName: PropTypes.string.isRequired
-}
+};
 
 export default AnyUserNameWrapper;
-

--- a/client/src/components/contexts/DataContext/DataContext.js
+++ b/client/src/components/contexts/DataContext/DataContext.js
@@ -1,7 +1,11 @@
 import React from 'react';
 
 export const DataContext = React.createContext({
-    userName: 'unknown',
+    userName: {
+        firstName: '',
+        lastName: '',
+        fullName: ''
+    },
     avatarSrc: '/images/noAvatar.svg',
     setUsername: () => {},
     setAvatarSrc: () => {}

--- a/client/src/components/contexts/DataContext/DataContext.js
+++ b/client/src/components/contexts/DataContext/DataContext.js
@@ -4,8 +4,7 @@ export const DataContext = React.createContext({
     userName: {
         firstName: '',
         lastName: '',
-        fullName: '',
-        nameOrder: 'normal'
+        fullName: ''
     },
     getFullName: () => {},
     avatarSrc: '/images/noAvatar.svg',

--- a/client/src/components/contexts/DataContext/DataContext.js
+++ b/client/src/components/contexts/DataContext/DataContext.js
@@ -4,7 +4,8 @@ export const DataContext = React.createContext({
     userName: {
         firstName: '',
         lastName: '',
-        fullName: ''
+        fullName: '',
+        nameOrder: 1
     },
     avatarSrc: '/images/noAvatar.svg',
     setUsername: () => {},

--- a/client/src/components/contexts/DataContext/DataContext.js
+++ b/client/src/components/contexts/DataContext/DataContext.js
@@ -5,7 +5,7 @@ export const DataContext = React.createContext({
         firstName: '',
         lastName: '',
         fullName: '',
-        nameOrder: 1
+        nameOrder: 'normal'
     },
     avatarSrc: '/images/noAvatar.svg',
     setUsername: () => {},

--- a/client/src/components/contexts/DataContext/DataContext.js
+++ b/client/src/components/contexts/DataContext/DataContext.js
@@ -7,6 +7,7 @@ export const DataContext = React.createContext({
         fullName: '',
         nameOrder: 'normal'
     },
+    getFullName: () => {},
     avatarSrc: '/images/noAvatar.svg',
     setUsername: () => {},
     setAvatarSrc: () => {}


### PR DESCRIPTION
### Explanation:
There are two new components, one for dynamically displaying the active user's name.
The other for dynamically displaying any name when passing in firstName and lastName in as props.

I couldn't dynamically set the name order on pages where only full names were fetched from the BE (such as Finance Admin page). For that, we'd need to refactor the DB so that it stores both firstName and lastName instead of just eg. a 'userName' or 'label'.

### Tests:
Test if name order changes when switching languages...
- ...in header
- ...in header search results
- ...on member cards
- ...on MemberDetail popup headers

### General check list (check boxes when completed with [x]):
[x] No generic imports (Bootstrap etc.)
[x] package.json is committed if I added any dependencies
[x] No errors/warnings in the browser console
[x] Testing steps added above
[x] Your code builds clean without any errors ( ﾟヮﾟ)/