### PR TITLE
Fix background page scrolling When Hamburger menu displayed in mobile…

### DIFF
--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -28,6 +28,7 @@ html {
 body {
     font-family: RobotoRegular;
     margin: 0;
+    overflow: hidden;
 }
 main {
     min-height: calc(100vh - 93px);
@@ -39,8 +40,11 @@ main {
         margin-left: 110px;
     }
     &.unscrollable {
-        overflow: hidden; 
-        position: fixed;
+        width: 100%;
+        //Optional but highly reccomended: enables momentum scrolling on iOS
+        -webkit-overflow-scrolling: touch;
+        
+
     }
 
     &>* {

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -41,8 +41,6 @@ main {
     }
     &.unscrollable {
         width: 100%;
-        //Optional but highly reccomended: enables momentum scrolling on iOS
-        -webkit-overflow-scrolling: touch;
     }
 
     &>* {

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -43,8 +43,6 @@ main {
         width: 100%;
         //Optional but highly reccomended: enables momentum scrolling on iOS
         -webkit-overflow-scrolling: touch;
-        
-
     }
 
     &>* {
@@ -53,7 +51,6 @@ main {
         margin-left: auto;
     }
 }
-
 
 /* --- custom checkbox --- */
 input[type="checkbox"] {

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -38,6 +38,10 @@ main {
     @include minQ(768px) {
         margin-left: 110px;
     }
+    &.unscrollable {
+        overflow: hidden; 
+        position: fixed;
+    }
 
     &>* {
         max-width: 2000px;
@@ -45,6 +49,7 @@ main {
         margin-left: auto;
     }
 }
+
 
 /* --- custom checkbox --- */
 input[type="checkbox"] {

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -26,7 +26,9 @@ const Main = () => {
 
     const location = useLocation();
 
-    const { pageAndNavbarTitles } = useContext(UIcontext).dictionary;
+    const { isHamburgerOpen, dictionary } = useContext(UIcontext);
+    const { pageAndNavbarTitles } = dictionary;
+    
 
     useEffect(() => {
         const url = location.pathname;
@@ -41,7 +43,7 @@ const Main = () => {
         <div className='grid-container'>
             <Header activePage={pageName} />
             <Navbar navStyle="sidenav" />
-            <main className="align">
+            <main className = {`align ${isHamburgerOpen ? 'unscrollable' : ''}`} >
                 <Switch>
                     <Route exact path='/app/dashboard'       render={(props) => <Dashboard {...props} /> } />
                     <Route exact path='/app/personal'        render={(props) => <Personal {...props} /> } />


### PR DESCRIPTION
# Description
This feature makes it possible for mobile views to scroll up and down in the Hamburger menu without scrolling the page in the background at the same time. Only works when the menu is opened on a smaller screen where it toggles from the top. 

Fixes #14 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Opened the menu testing on different screen sizes and scrolled up & down
- [x] Opened every background page n different screen sizes and scrolled up & down. !!!Discovered a bug (photo attached below)!!!

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (no need)
- [ ] I have made corresponding changes to the documentation (no need)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (tested manually)
- [x] Any dependent changes have been merged and published in downstream modules

![image](https://user-images.githubusercontent.com/58012860/100710877-43f86d80-3365-11eb-9277-201a79c0bd8c.png)
