### PR TITLE
Add icon to the superuser accordion dropdown

### DIFF
--- a/client/src/pages/Admins/Superuser/FilterAccordion/FilterAccordion.js
+++ b/client/src/pages/Admins/Superuser/FilterAccordion/FilterAccordion.js
@@ -1,10 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { UIcontext } from '../../../../components/contexts/UIcontext/UIcontext';
 
 import './FilterAccordion.scss';
 
 import { ReactComponent as Cross } from '../../../../components/icons/cross.svg';
+import { ReactComponent as Arrow } from '../../../../components/Form/formIcons/arrow-up.svg';
 import SearchBar from '../../../../components/Search/SearchBar';
 import Checkbox from '../../../../components/Form/Checkbox/Checkbox';
 
@@ -20,6 +21,7 @@ import Card from 'react-bootstrap/Card';
     --------------------------------------
 */
 const FilterAccordion = (props) => {
+    const [dropDownVisible, setDropDownVisible] = useState(false);
     const { superuser } = useContext(UIcontext).dictionary;
     const { FILTERMEMBERS, FILTERTEXT, FILTERSHOW, FILTERALL, FILTERREGISTERED, FILTERUNREGISTERED, RESETFILTERS, FILTERSUPERUSER, FILTERFINADMIN, FILTEREVENTADMIN, FILTERYOGAADMIN, FILTERNOROLE } = superuser;
 
@@ -37,7 +39,10 @@ const FilterAccordion = (props) => {
         <Accordion onKeyDown={preventSubmit} className="su-filter-accordion">
             <Card>
                 <Card.Header>
-                    <Accordion.Toggle as={Button} variant="primary" eventKey="0">
+                    <Accordion.Toggle onClick={() => setDropDownVisible(prevState => !prevState)} as={Button} variant="primary" eventKey="0">
+                        <span className="arrow-icon" eventKey="0">
+                            <Arrow className={dropDownVisible ? "arrowUp" : "arrowDown"}/>
+                        </span>
                         {FILTERMEMBERS}
                     </Accordion.Toggle>
                 </Card.Header>

--- a/client/src/pages/Admins/Superuser/FilterAccordion/FilterAccordion.scss
+++ b/client/src/pages/Admins/Superuser/FilterAccordion/FilterAccordion.scss
@@ -20,7 +20,30 @@
                 height: 100%;
                 border-radius: 0;
                 text-align: left;
+                display: flex;
+                align-items: center;
             }
+
+                .arrow-icon {
+                    display: flex;
+                    height: 100%;
+                    width: 15px;
+                    margin: 0 15px 0 0;
+                    float: left;
+                    fill: #fff;
+
+                    svg {
+                        height: 100%;
+                        transition: all .5s;
+
+                        &.arrowDown {
+                            transform: rotate(180deg);
+                        }
+                        &.arrowUp {
+                            transform: rotate(0deg);
+                        }
+                    }
+                }
         }
 
         .card-body {


### PR DESCRIPTION
# Description
This PR is about adding an arrow icon to the superuser accordion dropdown making it more obvious for the user to understand that it's a dropdown.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [X] Tested the functioning of the arrow up and down both on mobile and desktop version

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not needed)
- [ ] I have made corresponding changes to the documentation (not needed)
- [X] My changes generate no new warnings

![image](https://user-images.githubusercontent.com/58012860/102404943-41b92480-3f9d-11eb-9019-4e6e06a3d00c.png)
