### PR TITLE
Display when no superuser was found

### DIFF
--- a/client/src/languages/en.json
+++ b/client/src/languages/en.json
@@ -119,7 +119,8 @@
         "FILTEREVENTADMIN": "event admin",
         "FILTERYOGAADMIN": "yoga admin",
         "FILTERNOROLE": "no role",
-        "RESETFILTERS": "Reset filters"
+        "RESETFILTERS": "Reset filters",
+        "NOMEMBERFOUND": "No such member was found"
     },
 
     "superuserAddMember": {

--- a/client/src/languages/hu.json
+++ b/client/src/languages/hu.json
@@ -119,7 +119,8 @@
         "FILTEREVENTADMIN": "esemény szervező",
         "FILTERYOGAADMIN": "jóga admin",
         "FILTERNOROLE": "nincs szerep",
-        "RESETFILTERS": "Szűrők törlése"
+        "RESETFILTERS": "Szűrők törlése",
+        "NOMEMBERFOUND": "Nem találtunk ilyen tagot"
     },
 
     "superuserAddMember": {

--- a/client/src/pages/Admins/Superuser/Superuser.js
+++ b/client/src/pages/Admins/Superuser/Superuser.js
@@ -269,6 +269,7 @@ class Superuser extends Component {
     renderMembers = () => {
         const { memberData } = this.state;
         const filteredUsers = memberData.filter(user => this.checkFilters(user));
+        const { NOMEMBERFOUND } = this.context.dictionary.superuser;
 
         return (
             // check if user passes all filters
@@ -296,7 +297,7 @@ class Superuser extends Component {
                             </Button>
                         </td>
                     </tr>
-                ) : <tr><td>No superuser was found</td></tr>
+                ) : <tr><td>{ NOMEMBERFOUND }</td></tr>
         );
     }
 

--- a/client/src/pages/Admins/Superuser/Superuser.js
+++ b/client/src/pages/Admins/Superuser/Superuser.js
@@ -243,25 +243,25 @@ class Superuser extends Component {
     checkFilters = (user) => {
         const { roleFilter, textFilterValue, registeredFilterValue } = this.state;
 
-        // eslint-disable-next-line no-multi-spaces
+            // eslint-disable-next-line no-multi-spaces
         const passedEmailFilter =   user.email.substring(0, user.email.indexOf('@')).toLowerCase().includes(textFilterValue.toLowerCase()) ||
-                                    user.label.toLowerCase().includes(textFilterValue.toLowerCase());
+        user.label.toLowerCase().includes(textFilterValue.toLowerCase());
 
         // eslint-disable-next-line no-multi-spaces
         const passedRoleFilter =    !(roleFilter.filterSuperuser || roleFilter.filterFinanceAdmin || roleFilter.filterEventAdmin || roleFilter.filterYogaAdmin || roleFilter.filterNoRole) ||
-                                    (user.isSuperuser && roleFilter.filterSuperuser) ||
-                                    (user.isFinanceAdmin && roleFilter.filterFinanceAdmin) ||
-                                    (user.isEventAdmin && roleFilter.filterEventAdmin) ||
-                                    (user.isYogaAdmin && roleFilter.filterYogaAdmin) ||
-                                    (
-                                        !(user.isSuperuser || user.isFinanceAdmin || user.isEventAdmin || user.isYogaAdmin) &&
-                                        roleFilter.filterNoRole
-                                    );
+                (user.isSuperuser && roleFilter.filterSuperuser) ||
+                (user.isFinanceAdmin && roleFilter.filterFinanceAdmin) ||
+                (user.isEventAdmin && roleFilter.filterEventAdmin) ||
+                (user.isYogaAdmin && roleFilter.filterYogaAdmin) ||
+                (
+                    !(user.isSuperuser || user.isFinanceAdmin || user.isEventAdmin || user.isYogaAdmin) &&
+                    roleFilter.filterNoRole
+                );
 
         // eslint-disable-next-line no-multi-spaces
         const passedRegisteredFilter =  (registeredFilterValue === 'all') ||
-                                        (user.registered && registeredFilterValue !== 'unregistered') ||
-                                        (!user.registered && registeredFilterValue !== 'registered');
+                    (user.registered && registeredFilterValue !== 'unregistered') ||
+                    (!user.registered && registeredFilterValue !== 'registered');
 
         return passedEmailFilter && passedRoleFilter && passedRegisteredFilter;
     }
@@ -269,12 +269,13 @@ class Superuser extends Component {
     // *** RENDER ROWS *** //
     renderMembers = () => {
         const { memberData } = this.state;
+        const filteredUsers = memberData.filter(user => this.checkFilters(user));
 
         return (
-            memberData.map((user, key) => (
-                // check if user passes all filters
-                (this.checkFilters(user)) ? (
-                    <tr key={ key }>
+            // check if user passes all filters
+            (filteredUsers.length > 0) ? 
+                filteredUsers.map((user, index) => 
+                    <tr key={ index }>
                         <td className="name-cells">
                             <span>{user.label}</span>
                             {user.registered && <VerifiedIcon />}
@@ -286,18 +287,17 @@ class Superuser extends Component {
                             }
                         </td>
                         <td className="settings-cells icon-btn">
-                            <Button id={key} onClick={this.openUpdateUserSettingsDialog}>
+                            <Button id={index} onClick={this.openUpdateUserSettingsDialog}>
                                 <SettingsIcon />
                             </Button>
                         </td>
                         <td className="delete-icon-cell icon-btn">
-                            <Button variant='outline-danger' id={ key } onClick={this.openDelete}>
+                            <Button variant='outline-danger' id={ index } onClick={this.openDelete}>
                                 <Bin className='delete-user' />
                             </Button>
                         </td>
                     </tr>
-                ) : (null)
-            ))
+                ) : <tr><td>No superuser was found</td></tr>
         );
     }
 

--- a/client/src/pages/Admins/Superuser/Superuser.js
+++ b/client/src/pages/Admins/Superuser/Superuser.js
@@ -40,7 +40,8 @@ class Superuser extends Component {
         alertType: '',
         alertParam: '',
         memberRoles: {},
-        memberLevel: ''
+        memberLevel: '',
+        renderedUsers: []
     };
 
     /* ------------ General functions ------------ */
@@ -50,11 +51,17 @@ class Superuser extends Component {
             fields: ['email', 'isSuperuser', 'isFinanceAdmin', 'isEventAdmin', 'isYogaAdmin', 'label', 'registered', 'level']
         })
             .then((data) => {
-                this.setState({ memberData: data.reverse()});
+
+                const reverseData = data.reverse();
+                this.setState({ 
+                    memberData: reverseData, 
+                    renderedUsers: reverseData.map((member) => member.email)
+                });
             }).catch((err) => {
                 this.setState({ showAlert: true, alertMessage: err.message, alertType: 'ERROR' });
-            });
+            });   
     }
+
 
     closeAlert = () => {
         this.setState({ showAlert: false, alertMessage: '', alertType: '' });
@@ -62,7 +69,12 @@ class Superuser extends Component {
 
     /* ------------ FilterAccordion functions ------------ */
     handleEmailFilterChange = (inputValue) => {
-        this.setState({ textFilterValue: inputValue });
+        const renderedMemberData = this.state.memberData.filter((member) => this.checkFilters(member));
+        this.setState({
+                textFilterValue: inputValue,
+                renderedUsers: renderedMemberData.map((member) => member.email)
+        });
+        console.log(renderedMemberData);
     }
 
     handleSearchIconClick = (event) => {
@@ -234,6 +246,7 @@ class Superuser extends Component {
         // eslint-disable-next-line no-multi-spaces
         const passedEmailFilter =   user.email.substring(0, user.email.indexOf('@')).toLowerCase().includes(textFilterValue.toLowerCase()) ||
                                     user.label.toLowerCase().includes(textFilterValue.toLowerCase());
+
         // eslint-disable-next-line no-multi-spaces
         const passedRoleFilter =    !(roleFilter.filterSuperuser || roleFilter.filterFinanceAdmin || roleFilter.filterEventAdmin || roleFilter.filterYogaAdmin || roleFilter.filterNoRole) ||
                                     (user.isSuperuser && roleFilter.filterSuperuser) ||


### PR DESCRIPTION
# Description
This feature displays "no superuser was found" if there are no search results in the superuser filter accordion. 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [X] Tested with all kinds of names both on mobile and desktop view. 
- [X] Tested with consoling the current user object out

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

# Additional comment: 
We might want to consider doing denounce on the filtering function so it won't reload every time a letter is typed and would wait until the typing slows down / stops. 