### PR TITLE
Feature/#59 finance summary card selects relevant finance tab

### DIFF
--- a/client/src/components/FinanceDashboard/FinanceDashboard.tsx
+++ b/client/src/components/FinanceDashboard/FinanceDashboard.tsx
@@ -11,9 +11,10 @@ import { ReactComponent as Angel } from '../icons/fin_angel.svg';
 interface FinanceDashboardProps {
     balance: Balance;
     onError: (error: Error) => void;
+    onClick?: (pocket: string) => void;
 }
 
-const FinanceDashboard: React.FC<FinanceDashboardProps> = ({ balance, onError }) => {
+const FinanceDashboard: React.FC<FinanceDashboardProps> = ({ balance, onError, onClick }) => {
     const { financeDashboard, financePockets } = useContext(UIcontext).dictionary;
     const { BALANCE } = financeDashboard;
     const lang = localStorage.getItem('lang');
@@ -28,6 +29,12 @@ const FinanceDashboard: React.FC<FinanceDashboardProps> = ({ balance, onError })
         }
     };
 
+    const handleClick: React.MouseEventHandler<HTMLElement> = (event) => {
+        const { pocket } = event.currentTarget.dataset;
+        console.log(pocket);
+        onClick && pocket && onClick(pocket);
+    };
+
     return (
         <div className="overview" >
             <div className="outer">
@@ -37,7 +44,12 @@ const FinanceDashboard: React.FC<FinanceDashboardProps> = ({ balance, onError })
                         const financePocket = financePockets[pocket.toUpperCase()];
 
                         return (
-                            <div key={index} className="fin-card">
+                            <div
+                                key={index}
+                                className="fin-card"
+                                onClick={handleClick}
+                                data-pocket={pocket}
+                            >
                                 <div className="fin-card-1st">
                                     <div>{financePocket} {BALANCE}:</div>
                                     <div>{getIcon(pocket)}</div>
@@ -63,7 +75,8 @@ FinanceDashboard.propTypes = {
         event: PropTypes.number.isRequired,
         angel: PropTypes.number.isRequired
     }).isRequired,
-    onError: PropTypes.func.isRequired
+    onError: PropTypes.func.isRequired,
+    onClick: PropTypes.func
 };
 
 export default FinanceDashboard;

--- a/client/src/components/FinanceDashboard/FinanceDashboard.tsx
+++ b/client/src/components/FinanceDashboard/FinanceDashboard.tsx
@@ -31,7 +31,6 @@ const FinanceDashboard: React.FC<FinanceDashboardProps> = ({ balance, onError, o
 
     const handleClick: React.MouseEventHandler<HTMLElement> = (event) => {
         const { pocket } = event.currentTarget.dataset;
-        console.log(pocket);
         onClick && pocket && onClick(pocket);
     };
 

--- a/client/src/components/TransactionTabs/TransactionTabs.tsx
+++ b/client/src/components/TransactionTabs/TransactionTabs.tsx
@@ -6,6 +6,7 @@ import { UIcontext } from '../contexts/UIcontext/UIcontext';
 import './TransactionTabs.scss';
 import PropTypes from 'prop-types';
 import FinanceTransactionPropType from '../../proptypes/FinanceTransactionPropType';
+import { SelectCallback } from 'react-bootstrap/esm/helpers';
 
 interface TransactionTabsProps {
     transactions: Transactions;
@@ -15,6 +16,7 @@ interface TransactionTabsProps {
     openAddDebt?: (pocket: string) => void;
     openDeleteTransaction?: (transaction: TransactionToDelete) => void;
     activeTab?: string;
+    changeActiveTab?: (pocket: string) => void;
 };
 
 const TransactionTabs: React.FC<TransactionTabsProps> = (props) => {
@@ -25,25 +27,30 @@ const TransactionTabs: React.FC<TransactionTabsProps> = (props) => {
         openAddPayment,
         openAddDebt,
         openDeleteTransaction,
-        activeTab
+        activeTab,
+        changeActiveTab
     } = props;
     const { financePockets } = useContext(UIcontext).dictionary;
 
+    const handleSelect: SelectCallback = (eventKey, event) => {
+        changeActiveTab && eventKey && changeActiveTab(eventKey);
+    };
+
     return (
-        <Tabs className="MainTabs" bsPrefix="active" defaultActiveKey={activeTab}>
-            {Object.entries(transactions).map((pocket) => {
-                const tabTitle = financePockets[pocket[0].toUpperCase()];
+        <Tabs className="MainTabs" bsPrefix="active" activeKey={activeTab} onSelect={handleSelect}>
+            {Object.entries(transactions).map(([pocketName, financeTransactions]) => {
+                const tabTitle = financePockets[pocketName.toUpperCase()];
 
                 return (
-                    <Tab title={tabTitle} eventKey={pocket[0]} key={pocket[0]}>
+                    <Tab title={tabTitle} eventKey={pocketName} key={pocketName}>
                         <TransactionTable
-                            transactionArray={pocket[1]}
+                            transactionArray={financeTransactions}
                             isFinAdmin={isFinAdmin}
                             openAddPayment={openAddPayment}
                             openAddDebt={openAddDebt}
                             openDeleteTransaction={openDeleteTransaction}
                             onError={onError}
-                            pocket={pocket[0]}
+                            pocket={pocketName}
                         />
                     </Tab>
                 );
@@ -64,7 +71,8 @@ TransactionTabs.propTypes = {
     openAddPayment: PropTypes.func,
     openAddDebt: PropTypes.func,
     openDeleteTransaction: PropTypes.func,
-    activeTab: PropTypes.string
+    activeTab: PropTypes.string,
+    changeActiveTab: PropTypes.func
 };
 
 export default TransactionTabs;

--- a/client/src/pages/Admins/AdminFinance/AdminFinance.tsx
+++ b/client/src/pages/Admins/AdminFinance/AdminFinance.tsx
@@ -38,6 +38,10 @@ const AdminFinance: React.FC<Record<string, unknown>> = (props) => {
         setTransactionType('debt');
     };
 
+    const changeActiveTab = (pocket: string): void => {
+        setActiveTab(pocket);
+    };
+
     const closeTransactionDialog = (): void => {
         setShowAddTransaction(false);
         setPaymentDialogPocketName('');
@@ -125,6 +129,7 @@ const AdminFinance: React.FC<Record<string, unknown>> = (props) => {
                 openDeleteTransaction={openDeleteTransaction}
                 isFinAdmin
                 activeTab={activeTab}
+                changeActiveTab={changeActiveTab}
             />
             {showAddTransaction && transactionType && (
                 <AddTransactionDialog

--- a/client/src/pages/Admins/AdminFinance/AdminFinance.tsx
+++ b/client/src/pages/Admins/AdminFinance/AdminFinance.tsx
@@ -72,8 +72,8 @@ const AdminFinance: React.FC<Record<string, unknown>> = (props) => {
             }`
         })
             .then((data) => {
-                setRefreshFinanceData(Date.now());
                 setActiveTabFromAdmin(pocketName);
+                setRefreshFinanceData(Date.now());
             })
             .catch((err) => {
                 setShowAlert(true);
@@ -103,8 +103,8 @@ const AdminFinance: React.FC<Record<string, unknown>> = (props) => {
             }`
         })
             .then((data) => {
-                setRefreshFinanceData(Date.now());
                 setActiveTabFromAdmin(pocket);
+                setRefreshFinanceData(Date.now());
             })
             .catch((err) => {
                 setShowAlert(true);

--- a/client/src/pages/Admins/AdminFinance/AdminFinance.tsx
+++ b/client/src/pages/Admins/AdminFinance/AdminFinance.tsx
@@ -16,7 +16,7 @@ const AdminFinance: React.FC<Record<string, unknown>> = (props) => {
     const [showDeleteTransaction, setShowDeleteTransaction] = useState(false);
     const [transaction, setTransaction] = useState<TransactionToDelete | null>(null);
     const [refreshFinanceData, setRefreshFinanceData] = useState(0);
-    const [activeTab, setActiveTab] = useState('membership');
+    const [activeTabFromAdmin, setActiveTabFromAdmin] = useState('membership');
     const [showAlert, setShowAlert] = useState(false);
     const [alertMessage, setAlertMessage] = useState('');
     const [alertType, setAlertType] = useState<ALERT>('NOALERT');
@@ -36,10 +36,6 @@ const AdminFinance: React.FC<Record<string, unknown>> = (props) => {
         setShowAddTransaction(true);
         setPaymentDialogPocketName(pocket);
         setTransactionType('debt');
-    };
-
-    const changeActiveTab = (pocket: string): void => {
-        setActiveTab(pocket);
     };
 
     const closeTransactionDialog = (): void => {
@@ -77,7 +73,7 @@ const AdminFinance: React.FC<Record<string, unknown>> = (props) => {
         })
             .then((data) => {
                 setRefreshFinanceData(Date.now());
-                setActiveTab(pocketName);
+                setActiveTabFromAdmin(pocketName);
             })
             .catch((err) => {
                 setShowAlert(true);
@@ -108,7 +104,7 @@ const AdminFinance: React.FC<Record<string, unknown>> = (props) => {
         })
             .then((data) => {
                 setRefreshFinanceData(Date.now());
-                setActiveTab(pocket);
+                setActiveTabFromAdmin(pocket);
             })
             .catch((err) => {
                 setShowAlert(true);
@@ -128,8 +124,7 @@ const AdminFinance: React.FC<Record<string, unknown>> = (props) => {
                 openAddDebt={openAddDebt}
                 openDeleteTransaction={openDeleteTransaction}
                 isFinAdmin
-                activeTab={activeTab}
-                changeActiveTab={changeActiveTab}
+                activeTabFromAdmin={activeTabFromAdmin}
             />
             {showAddTransaction && transactionType && (
                 <AddTransactionDialog

--- a/client/src/pages/Finances/FinanceContainer/FinanceContainer.tsx
+++ b/client/src/pages/Finances/FinanceContainer/FinanceContainer.tsx
@@ -13,6 +13,7 @@ interface FinanceContainerProps {
     openAddDebt?: (pocket: string) => void;
     openDeleteTransaction?: (transaction: TransactionToDelete) => void;
     activeTab?: string;
+    changeActiveTab?: (pocket: string) => void;
 }
 
 const FinanceContainer: React.FC<FinanceContainerProps> = (props) => {
@@ -22,7 +23,8 @@ const FinanceContainer: React.FC<FinanceContainerProps> = (props) => {
         openAddPayment,
         openAddDebt,
         openDeleteTransaction,
-        activeTab
+        activeTab,
+        changeActiveTab
     } = props;
     const [financeData, setFinanceData] = useState<FinanceAccount | null>(null);
     const [errorState, setErrorState] = useState(0);
@@ -80,6 +82,7 @@ const FinanceContainer: React.FC<FinanceContainerProps> = (props) => {
                         key={reRender}
                         balance={financeData.balance}
                         onError={handleError}
+                        onClick={changeActiveTab}
                     />
                     <TransactionTabs
                         transactions={financeData.transactions}
@@ -89,6 +92,7 @@ const FinanceContainer: React.FC<FinanceContainerProps> = (props) => {
                         openAddDebt={openAddDebt}
                         openDeleteTransaction={openDeleteTransaction}
                         activeTab={activeTab}
+                        changeActiveTab={changeActiveTab}
                     />
                 </>
             )}
@@ -102,7 +106,8 @@ FinanceContainer.propTypes = {
     openAddPayment: PropTypes.func,
     openAddDebt: PropTypes.func,
     openDeleteTransaction: PropTypes.func,
-    activeTab: PropTypes.string
+    activeTab: PropTypes.string,
+    changeActiveTab: PropTypes.func
 };
 
 export default FinanceContainer;

--- a/client/src/pages/Finances/FinanceContainer/FinanceContainer.tsx
+++ b/client/src/pages/Finances/FinanceContainer/FinanceContainer.tsx
@@ -12,8 +12,7 @@ interface FinanceContainerProps {
     openAddPayment?: (pocket: string) => void;
     openAddDebt?: (pocket: string) => void;
     openDeleteTransaction?: (transaction: TransactionToDelete) => void;
-    activeTab?: string;
-    changeActiveTab?: (pocket: string) => void;
+    activeTabFromAdmin?: string;
 }
 
 const FinanceContainer: React.FC<FinanceContainerProps> = (props) => {
@@ -23,12 +22,16 @@ const FinanceContainer: React.FC<FinanceContainerProps> = (props) => {
         openAddPayment,
         openAddDebt,
         openDeleteTransaction,
-        activeTab,
-        changeActiveTab
+        activeTabFromAdmin,
     } = props;
     const [financeData, setFinanceData] = useState<FinanceAccount | null>(null);
     const [errorState, setErrorState] = useState(0);
     const [reRender, setReRender] = useState(0); // fine HACK to rerender Component when new data is available.
+    const [activeTab, setActiveTab] = useState(activeTabFromAdmin);
+
+    const changeActiveTab = (pocket: string): void => {
+        setActiveTab(pocket);
+    };
 
     const sortByDueDate = (t1: FinanceTransaction, t2: FinanceTransaction): number => {
         return new Date(t2.dueDate).getTime() - new Date(t1.dueDate).getTime();
@@ -106,8 +109,7 @@ FinanceContainer.propTypes = {
     openAddPayment: PropTypes.func,
     openAddDebt: PropTypes.func,
     openDeleteTransaction: PropTypes.func,
-    activeTab: PropTypes.string,
-    changeActiveTab: PropTypes.func
+    activeTabFromAdmin: PropTypes.string,
 };
 
 export default FinanceContainer;


### PR DESCRIPTION
On Finance Admin & Finances pages, when clicking summary card, the corresponding finance tab gets selected.

https://github.com/sanghanet/sanghanet/issues/59

How to test:
- go to Finance Admin page, click tabs and summary cards as much as you want. Add / delete transactions.
- go to Finances page, click tabs and summary cards as much as you want. 